### PR TITLE
1:1 should not be an inner class

### DIFF
--- a/90-wshaper
+++ b/90-wshaper
@@ -64,7 +64,7 @@ if [ "$IF" = "$DEV" ] && [ "$STATUS" = "up" ]; then
 	# Class 1:20 Internet - normal priority
 	# Class 1:30 Internet - low priority
 	$TC class add dev $DEV parent 1: classid 1:1 htb rate ${ETH_UPLINK}kbit ceil ${ETH_UPLINK}kbit burst 1024k prio 2
-	$TC class add dev $DEV parent 1:1 classid 1:2 htb rate ${UPLINK}kbit ceil ${UPLINK}kbit burst 256k prio 2
+	$TC class add dev $DEV parent 1: classid 1:2 htb rate ${UPLINK}kbit ceil ${UPLINK}kbit burst 256k prio 2
 	$TC class add dev $DEV parent 1:2 classid 1:10 htb rate $[8*$UPLINK/10]kbit ceil ${UPLINK}kbit burst 256k prio 1
 	$TC class add dev $DEV parent 1:2 classid 1:20 htb rate $[2*$UPLINK/10]kbit ceil ${UPLINK}kbit burst 64k prio 2
 	$TC class add dev $DEV parent 1:2 classid 1:30 htb rate 1kbit ceil ${UPLINK}kbit burst 6k prio 3


### PR DESCRIPTION
Maybe it was a typo. 1:1 should not be an inner class otherwise shaping will not happen according to document.

7.1.2. Shaping

One of the most common applications of HTB involves shaping transmitted traffic to a specific rate.

All shaping occurs in leaf classes. No shaping occurs in inner or root classes as they only exist to suggest how the borrowing model should distribute available tokens.